### PR TITLE
Changes: in AmazonOrderList to create the multiple marketplaces request

### DIFF
--- a/src/AmazonOrderList.php
+++ b/src/AmazonOrderList.php
@@ -67,15 +67,18 @@ class AmazonOrderList extends AmazonOrderCore implements Iterator
         }
 
         if (isset($store[$s]) && array_key_exists('marketplaceId', $store[$s])) {
-            //$this->options['MarketplaceId.Id.1'] = $store[$s]['marketplaceId'];
             //Make possible to pass multiple MarketplaceIds
             //The request will have a list of Marketplaces as:
             //MarketplaceId.Id.x1 MarketplaceId.Id.x2 MarketplaceId.Id.x3
-            $count_marketplace = count($store[$s]['marketplaceId']);
-            for ($i = 0; $i < $count_marketplace; ++$i) {
-                $parameter_increment = $i + 1;
-                $marketplace_parameter = 'MarketplaceId.Id.' . $parameter_increment;
-                $this->options[$marketplace_parameter] = $store[$s]['marketplaceId'][$i];
+            if (is_array($store[$s]['marketplaceId'])) {
+                $count_marketplace = count($store[$s]['marketplaceId']);
+                for ($i = 0; $i < $count_marketplace; ++$i) {
+                    $parameter_increment = $i + 1;
+                    $marketplace_parameter = 'MarketplaceId.Id.' . $parameter_increment;
+                    $this->options[$marketplace_parameter] = $store[$s]['marketplaceId'][$i];
+                }
+            } else {
+                $this->options['MarketplaceId.Id.1'] = $store[$s]['marketplaceId'];
             }
         } else {
             $this->log("Marketplace ID is missing", 'Urgent');

--- a/src/AmazonOrderList.php
+++ b/src/AmazonOrderList.php
@@ -71,11 +71,11 @@ class AmazonOrderList extends AmazonOrderCore implements Iterator
             //The request will have a list of Marketplaces as:
             //MarketplaceId.Id.x1 MarketplaceId.Id.x2 MarketplaceId.Id.x3
             if (is_array($store[$s]['marketplaceId'])) {
-                $count_marketplace = count($store[$s]['marketplaceId']);
-                for ($i = 0; $i < $count_marketplace; ++$i) {
-                    $parameter_increment = $i + 1;
-                    $marketplace_parameter = 'MarketplaceId.Id.' . $parameter_increment;
-                    $this->options[$marketplace_parameter] = $store[$s]['marketplaceId'][$i];
+                $parameterIncrement = 1;
+                foreach ($store[$s]['marketplaceId'] as $marketplace) {
+                    $marketplaceParameter = 'MarketplaceId.Id.' . $parameterIncrement;
+                    $this->options[$marketplaceParameter] = $marketplace;
+                    $parameterIncrement += 1;
                 }
             } else {
                 $this->options['MarketplaceId.Id.1'] = $store[$s]['marketplaceId'];

--- a/src/AmazonOrderList.php
+++ b/src/AmazonOrderList.php
@@ -67,7 +67,16 @@ class AmazonOrderList extends AmazonOrderCore implements Iterator
         }
 
         if (isset($store[$s]) && array_key_exists('marketplaceId', $store[$s])) {
-            $this->options['MarketplaceId.Id.1'] = $store[$s]['marketplaceId'];
+            //$this->options['MarketplaceId.Id.1'] = $store[$s]['marketplaceId'];
+            //Make possible to pass multiple MarketplaceIds
+            //The request will have a list of Marketplaces as:
+            //MarketplaceId.Id.x1 MarketplaceId.Id.x2 MarketplaceId.Id.x3
+            $count_marketplace = count($store[$s]['marketplaceId']);
+            for ($i = 0; $i < $count_marketplace; ++$i) {
+                $parameter_increment = $i + 1;
+                $marketplace_parameter = 'MarketplaceId.Id.' . $parameter_increment;
+                $this->options[$marketplace_parameter] = $store[$s]['marketplaceId'][$i];
+            }
         } else {
             $this->log("Marketplace ID is missing", 'Urgent');
         }

--- a/tests/mocks/classes/Config.php
+++ b/tests/mocks/classes/Config.php
@@ -7,6 +7,12 @@
 
 class Config
 {
+    const MARKETPLACE_1 = 'A1PA6795UKMFR9';
+    const MARKETPLACE_2 = 'APJ6JRA9NG5V4';
+    const MARKETPLACE_3 = 'A13V1IB3VIYZZH';
+    const MARKETPLACE_4 = 'A1RKKUPIHCS9HS';
+    const MARKETPLACE_5 = 'A1F83G8C2ARO7P';
+
     static function get($name)
     {
         $fakeConfig = [
@@ -15,7 +21,14 @@ class Config
             'amazon-mws.store' => [
                 'testStore' => [
                     'merchantId' => 'ABC_MARKET_1234',
-                    'marketplaceId' => 'ABC3456789456',
+                    //'marketplaceId' => 'ABC3456789456',
+                    'marketplaceId' => [
+                        self::MARKETPLACE_1,
+                        self::MARKETPLACE_2,
+                        self::MARKETPLACE_3,
+                        self::MARKETPLACE_4,
+                        self::MARKETPLACE_5
+                    ],
                     'keyId' => 'key',
                     'secretkey' => 'secret',
                 ],

--- a/tests/mocks/classes/Config.php
+++ b/tests/mocks/classes/Config.php
@@ -7,11 +7,11 @@
 
 class Config
 {
-    const MARKETPLACE_1 = 'A1PA6795UKMFR9';
-    const MARKETPLACE_2 = 'APJ6JRA9NG5V4';
-    const MARKETPLACE_3 = 'A13V1IB3VIYZZH';
-    const MARKETPLACE_4 = 'A1RKKUPIHCS9HS';
-    const MARKETPLACE_5 = 'A1F83G8C2ARO7P';
+    const MARKETPLACE_DE = 'A1PA6795UKMFR9';
+    const MARKETPLACE_IT = 'APJ6JRA9NG5V4';
+    const MARKETPLACE_FR = 'A13V1IB3VIYZZH';
+    const MARKETPLACE_ES = 'A1RKKUPIHCS9HS';
+    const MARKETPLACE_GB = 'A1F83G8C2ARO7P';
 
     static function get($name)
     {
@@ -23,11 +23,11 @@ class Config
                     'merchantId' => 'ABC_MARKET_1234',
                     //'marketplaceId' => 'ABC3456789456',
                     'marketplaceId' => [
-                        self::MARKETPLACE_1,
-                        self::MARKETPLACE_2,
-                        self::MARKETPLACE_3,
-                        self::MARKETPLACE_4,
-                        self::MARKETPLACE_5
+                        self::MARKETPLACE_DE,
+                        self::MARKETPLACE_IT,
+                        self::MARKETPLACE_FR,
+                        self::MARKETPLACE_ES,
+                        self::MARKETPLACE_GB
                     ],
                     'keyId' => 'key',
                     'secretkey' => 'secret',


### PR DESCRIPTION
Have the ability to create an OrderList request to get orders for multiple Marketplaces at the same time.
The changes that I made, only concerns the AmazonOrderList class. Other services from the SDK are not affected with the changes.